### PR TITLE
More Death Messages!

### DIFF
--- a/common/src/main/java/net/darkhax/deathknell/DeathKnellCommon.java
+++ b/common/src/main/java/net/darkhax/deathknell/DeathKnellCommon.java
@@ -11,13 +11,12 @@ import net.minecraft.tags.TagKey;
 import net.minecraft.world.damagesource.CombatEntry;
 import net.minecraft.world.damagesource.CombatTracker;
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageTypes;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.animal.IronGolem;
 import net.minecraft.world.entity.animal.PolarBear;
-import net.minecraft.world.entity.monster.Blaze;
-import net.minecraft.world.entity.monster.CaveSpider;
-import net.minecraft.world.entity.monster.Drowned;
-import net.minecraft.world.entity.monster.Guardian;
-import net.minecraft.world.entity.monster.Slime;
+import net.minecraft.world.entity.monster.*;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.AxeItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -30,18 +29,23 @@ public class DeathKnellCommon {
     private static final TagKey<Item> AXES = bind("axes");
 
     // Messages
-    private static final IDeathMessage GENERIC_SLAIN = new DeathMessageRandom("thwarted", "bonked", "defeated", "butchered", "assassinate", "eliminated", "extinguished", "terminated", "done_in", "executed", "stopped", "stifle", "slaughter", "exterminated", "vanquished", "bested", "trounced");
+    private static final IDeathMessage GENERIC_SLAIN = new DeathMessageRandom("thwarted", "bonked", "defeated", "butchered", "assassinate", "eliminated", "extinguished", "terminated", "done_in", "executed", "stopped", "stifle", "slaughter", "exterminated", "vanquished", "bested", "trounced", "ended", "perished", "demise");
     private static final IDeathMessage DEATH_BY_COOKIE = new DeathMessage("death_by_cookie");
     private static final IDeathMessage DEATH_BY_BOOK = new DeathMessage("death_by_book");
     private static final IDeathMessage DEATH_BY_AXE = new DeathMessage("death_by_axe");
-    private static final IDeathMessage BURNED_ALIVE = new DeathMessageRandom("incinerated", "reduce_to_ash", "cooked_alive");
+    private static final IDeathMessage BURNED_ALIVE = new DeathMessageRandom("incinerated", "reduce_to_ash", "cooked_alive", "fire_out");
     private static final IDeathMessage SPIDER_VENOM = new DeathMessage("spider_venom");
     private static final IDeathMessage SLIME_DEATH = new DeathMessageRandom("dissolve", "slime_food");
     private static final IDeathMessage POLAR_BEAR_DEATH = new DeathMessageRandom("respect_habitat", "disturb_den");
+    private static final IDeathMessage IRON_GOLEM_DEATH = new DeathMessage("saved_from_village");
     private static final IDeathMessage DROWNED_DEATH = new DeathMessage("watery_grave");
     private static final IDeathMessage GUARDIAN_DEATH = new DeathMessage("stared_down");
-    private static final IDeathMessage FALL_DEATH = new DeathMessageRandom("fall_bounce", "fall_gravity", "fall_parachute");
-    private static final IDeathMessage DROWN_DEATH = new DeathMessageRandom("drown_breath", "drown_fishes", "drown_fish_food");
+    private static final IDeathMessage PLAYER_DEATH = new DeathMessage("pwned");
+    private static final IDeathMessage FALL_DEATH = new DeathMessageRandom("fall_bounce", "fall_gravity", "fall_parachute", "fall_stub", "free_fall");
+    private static final IDeathMessage DROWN_DEATH = new DeathMessageRandom("drown_breath", "drown_fishes", "drown_fish_food", "drown_shark_bait", "drown_floundered");
+    private static final IDeathMessage ELYTRA_WALL_DEATH = new DeathMessageRandom("elytra_wall_bang", "elytra_wall_crash");
+    private static final IDeathMessage VOID_DEATH = new DeathMessageRandom("void_abyss", "void_infinity", "void_divide");
+
 
     private static CombatEntry getLastCombatEntry(AccessorCombatTracker tracker) {
         
@@ -69,6 +73,18 @@ public class DeathKnellCommon {
                     if (source.is(DamageTypeTags.IS_DROWNING) && tryPercent(0.6f)) {
 
                         return DROWN_DEATH.getMessage(deadMob);
+                    }
+
+                    //There is no actual DamageTypeTag for the elytra flying into a wall, but this still works
+                    if(source.is(DamageTypes.FLY_INTO_WALL) && tryPercent(0.6f)) {
+
+                        return ELYTRA_WALL_DEATH.getMessage(deadMob);
+                    }
+
+                    //Void death messages. The ALWAYS_MOST_SIGNIFICANT_FALL tag only has the void damage type applied
+                    if(source.is(DamageTypeTags.ALWAYS_MOST_SIGNIFICANT_FALL) && tryPercent(0.6f)) {
+
+                        return VOID_DEATH.getMessage(deadMob);
                     }
                 }
             }
@@ -102,6 +118,11 @@ public class DeathKnellCommon {
                     return POLAR_BEAR_DEATH.getMessage(deadMob, killer);
                 }
 
+                if (killer instanceof IronGolem && tryPercent(0.9f)) {
+
+                    return IRON_GOLEM_DEATH.getMessage(deadMob, killer);
+                }
+
                 if (killer instanceof Drowned && tryPercent(0.40f)) {
 
                     return DROWNED_DEATH.getMessage(deadMob, killer);
@@ -111,6 +132,12 @@ public class DeathKnellCommon {
 
                     return GUARDIAN_DEATH.getMessage(deadMob, killer);
                 }
+
+                if (killer instanceof Player && tryPercent(0.2f)) {
+
+                    return murderWeapon.hasCustomHoverName() ? PLAYER_DEATH.getSubMessage("item", deadMob, killer, murderWeapon) : PLAYER_DEATH.getMessage(deadMob, killer);
+                }
+
 
                 // Handle kills with specific types of items when the item used was not customised.
                 if (wasGenericKill) {

--- a/common/src/main/resources/assets/deathknell/lang/en_us.json
+++ b/common/src/main/resources/assets/deathknell/lang/en_us.json
@@ -39,25 +39,46 @@
   "message.deathknell.bested.item": "%1$s was bested by %2$s using %3$s",
   "message.deathknell.trounced": "%1$s was trounced by %2$s",
   "message.deathknell.trounced.item": "%1$s was trounced by %2$s using %3$s",
+  "message.deathknell.ended": "%1$s was ended by %2$s",
+  "message.deathknell.ended.item": "%1$s was bested by %2$s using %3$s",
+  "message.deathknell.perished": "%1$s perished whilst fighting %2$s",
+  "message.deathknell.perished.item": "%1$s perished by %3$s whilst fighting %2$s",
+  "message.deathknell.demise": "%2$s caused %1$s's demise",
+  "message.deathknell.demise.item": "%2$s caused %1$s's demise using %3$s",
+  "message.deathknell.pwned": "%1$s got pwned by %2$s",
+  "message.deathknell.pwned.item": "%1$s got pwned by %2$s using %3$s",
 
   "message.deathknell.down_with_ship": "%1$s went down with the ship",
 
   "message.deathknell.incinerated": "%1$s was incinerated by %2$s",
   "message.deathknell.reduce_to_ash": "%1$s was reduced to ash by %2$s",
   "message.deathknell.cooked_alive": "%1$s was cooked alive by %2$s",
+  "message.deathknell.fire_out": "%1$s couldn't put the fire out whilst fighting %2$s",
   "message.deathknell.spider_venom": "%1$s succame to %2$s venom",
   "message.deathknell.dissolve": "%1$s was dissolved by %2$s",
   "message.deathknell.slime_food": "%1$s became %2$s food",
   "message.deathknell.respect_habitat": "%1$s did not respect %2$s's habitat",
   "message.deathknell.disturb_den": "%1$s disturbed %2$s's den",
+  "message.deathknell.saved_from_village": "%2$s saved the village from %1$s",
   "message.deathknell.watery_grave": "%2$s sent %1$s to a watery grave",
   "message.deathknell.stared_down": "%1$s was stared down by %2$1",
 
   "message.deathknell.fall_bounce": "%1$s didn't bounce",
   "message.deathknell.fall_gravity": "%1$s was slain by Gravity",
   "message.deathknell.fall_parachute": "%1$s forgot their parachute",
+  "message.deathknell.fall_stub": "%1$s stubbed their toe and fell",
+  "message.deathknell.free_fall": "%1$s was freeeee, free-fallin'",
 
   "message.deathknell.drown_breath": "%1$s couldn't hold their breath",
   "message.deathknell.drown_fishes": "%1$s is sleeping with the fishes",
-  "message.deathknell.drown_fish_food": "%1$s became fish food"
+  "message.deathknell.drown_fish_food": "%1$s became fish food",
+  "message.deathknell.drown_shark_bait": "%1$s became shark bait",
+  "message.deathknell.drown_floundered": "%1$s floundered too hard",
+
+  "message.deathknell.elytra_wall_bang": "%1$s banged into a wall whilst flying",
+  "message.deathknell.elytra_wall_crash": "%1$s crashed into a wall",
+
+  "message.deathknell.void_abyss": "%1$s fell into the infinite abyss",
+  "message.deathknell.void_infinity": "%1$s fell into infinity plus one",
+  "message.deathknell.void_divide": "%1$s tried to divide by zero"
 }

--- a/common/src/main/resources/assets/deathknell/lang/en_us.json
+++ b/common/src/main/resources/assets/deathknell/lang/en_us.json
@@ -40,7 +40,7 @@
   "message.deathknell.trounced": "%1$s was trounced by %2$s",
   "message.deathknell.trounced.item": "%1$s was trounced by %2$s using %3$s",
   "message.deathknell.ended": "%1$s was ended by %2$s",
-  "message.deathknell.ended.item": "%1$s was bested by %2$s using %3$s",
+  "message.deathknell.ended.item": "%1$s was ended by %2$s using %3$s",
   "message.deathknell.perished": "%1$s perished whilst fighting %2$s",
   "message.deathknell.perished.item": "%1$s perished by %3$s whilst fighting %2$s",
   "message.deathknell.demise": "%2$s caused %1$s's demise",


### PR DESCRIPTION
A whole bunch of new death messages, pretty all the ones I sent you on Discord. Unlike my Tips PR, this is for Minecraft version 1.20.1.

Here is a list of the newly added messages. I've also DM'd you on Discord a consistently formatted version of the new messages based on the description from the Modrinth page incase you want to copy-paste them over there(GitHub wouldn't let me post it here for some reason). Everything is only done in en_us.json, as I am not familiar with any other language(unfortunately). Happy Modtoberfest!

<details>
  <summary>New Messages</summary>
Steve is always the player dying. Parentheses indicate that a named item special death message is possible.

### Generic Slain
- Steve was ended by Zombie( using Diamond Sword)
- Steve perished (by Diamond Sword) whilst fighting Zombie
- Zombie caused Steve's demise( using Diamond Sword)

### Fall Death
- Steve was freeeee, free-fallin
- Steve stubbed their toe and fell

### Drown Death
- Steve became shark bait
- Steve floundered too hard

### Elytra Wall (New)
- Steve banged into a wall whilst flying
- Steve crashed into a wall

### Void Death (New)
- Steve fell into the infinite abyss
- Steve fell into infinity plus one
- Steve tried to divide by zero

### Mob Specific Deaths
- Steve couldn't put the fire out whilst fighting Blaze
- Iron Golem saved the village from Steve
- Steve got pwned by Alex( using Diamond Sword)
</details>
